### PR TITLE
Adds some missing functionality from Memex StorageManager codebase

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -114,10 +114,10 @@ export class DexieStorageBackend extends backend.StorageBackend {
         const collectionDefinition = this.registry.collections[collection]
         await _processFieldsForWrites(collectionDefinition, object, this.stemmer)
         await this.dexie.table(collection).put(object)
-        
+
         return {object}
     }
-    
+
     async findObjects<T>(collection : string, query, findOpts : backend.FindManyOptions = {}) : Promise<Array<T>> {
         let coll = this.dexie.collection(collection).find(query)
 
@@ -136,7 +136,7 @@ export class DexieStorageBackend extends backend.StorageBackend {
         const docs = await coll.toArray()
         return docs as T[]
     }
-    
+
     async updateObjects(collection : string, query, updates, options : backend.UpdateManyOptions & {_transaction?} = {}) : Promise<backend.UpdateManyResult> {
         const { modifiedCount } = await this.dexie
             .collection(collection)
@@ -144,7 +144,7 @@ export class DexieStorageBackend extends backend.StorageBackend {
 
         // return modifiedCount
     }
-    
+
     async deleteObjects(collection : string, query, options : backend.DeleteManyOptions = {}) : Promise<backend.DeleteManyResult> {
         const { deletedCount } = await this.dexie
             .collection(collection)
@@ -153,7 +153,7 @@ export class DexieStorageBackend extends backend.StorageBackend {
         // return deletedCount
     }
 
-    async count(collection : string, query) {
+    async countObjects(collection : string, query) {
         return this.dexie.collection(collection).count(query)
     }
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -19,6 +19,8 @@ export interface IndexedDbImplementation {
 export type Stemmer = (text : string) => Set<string>
 export type SchemaPatcher = (schema: DexieSchema[]) => DexieSchema[]
 
+const IdentitySchemaPatcher: SchemaPatcher = f => f
+
 interface Props {
     dbName : string
     stemmer? : Stemmer
@@ -32,8 +34,6 @@ interface Props {
 }
 
 export class DexieStorageBackend extends backend.StorageBackend {
-    static DEF_SCHEMA_PATCHER: SchemaPatcher = f => f
-
     protected features : StorageBackendFeatureSupport = {
         count: true,
         createWithRelationships: true,
@@ -50,7 +50,7 @@ export class DexieStorageBackend extends backend.StorageBackend {
         dbName,
         idbImplementation = null,
         stemmer = null,
-        schemaPatcher = DexieStorageBackend.DEF_SCHEMA_PATCHER,
+        schemaPatcher = IdentitySchemaPatcher,
     } : Props) {
         super()
 

--- a/ts/schema.ts
+++ b/ts/schema.ts
@@ -11,7 +11,7 @@ export function getDexieHistory(storageRegistry: StorageRegistry) {
 
     Object.entries(storageRegistry.collectionsByVersion)
         .sort((left, right) => (left[0] < right[0] ? -1 : 1))
-        .forEach(([versionTimestamp, defs]) => {
+        .forEach(([, defs]) => {
             defs.forEach(def => (collections[def.name] = def))
             versions.push({
                 ...getDexieSchema(collections),
@@ -19,7 +19,7 @@ export function getDexieHistory(storageRegistry: StorageRegistry) {
             })
         })
 
-    return patchDirectLinksSchema(versions)
+    return versions
 }
 
 function getDexieSchema(collections: RegistryCollections) {
@@ -100,43 +100,4 @@ function convertIndexToDexieExps({ name: collection, fields, indices, relationsh
             return `${listPrefix}${indexDef.field}`
         })
         .join(', ')
-}
-
-/**
- * Takes the generated schema versions, based on the registed collections, and finds the
- * first one in which `directLinks` schema was added, then generates a "patch" schema.
- * This "patch" schema should contain the incorrect indexes that was accidently rolled out
- * to users at the release of our Direct Links feature. This should ensure Dexie knows about
- * both the incorrect indexes and how to drop those to migrate to the correct indexes.
- */
-function patchDirectLinksSchema(schemaVersions: DexieSchema[]): DexieSchema[] {
-    const firstAppears = schemaVersions.findIndex(
-        ({ schema }) => schema.directLinks != null,
-    )
-
-    // Return schemas as-is if direct links schema not found (tests)
-    if (firstAppears === -1) {
-        return schemaVersions
-    }
-
-    const preceding = schemaVersions[firstAppears - 1]
-
-    const patchedSchema = {
-        schema: {
-            ...preceding.schema,
-            directLinks: 'url, *pageTitle, *body, createdWhen',
-        },
-        migrations: [],
-        version: preceding.version + 1,
-    }
-
-    return [
-        ...schemaVersions.slice(0, firstAppears),
-        // Shim the schema with the incorrect indexes, so Dexie knows about its existence
-        patchedSchema,
-        // All subsequent schemas need to be 1 version higher to take the incorrect index schema into account
-        ...schemaVersions
-            .slice(firstAppears)
-            .map(schema => ({ ...schema, version: schema.version + 1 })),
-    ]
 }


### PR DESCRIPTION
Includes: 

- ~~`suggestObjects` method implementation~~
- support for `ignoreCase` flag in text-query supporting methods (count, find, suggest)