### PR TITLE
Add support for field preproc on updates

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -184,7 +184,7 @@ export class DexieStorageBackend extends backend.StorageBackend {
             coll = coll.limit(findOpts.limit)
         }
 
-        return await coll.toArray()
+        return coll.toArray()
     }
 
     async updateObjects(collection : string, query, updates, options : backend.UpdateManyOptions & {_transaction?} = {}) : Promise<backend.UpdateManyResult> {
@@ -253,7 +253,7 @@ export function _processFieldUpdates(updates, object) {
  * Handles mutation of a document to be inserted/updated to storage,
  * depending on needed pre-processing for a given indexed field.
  */
-export async function _processIndexedField(
+export function _processIndexedField(
     fieldName: string,
     indexDef: IndexDefinition,
     fieldDef: CollectionField,
@@ -265,7 +265,7 @@ export async function _processIndexedField(
             const fullTextField =
                 indexDef.fullTextIndexName ||
                 getTermsIndex(fieldName)
-            object[fullTextField] = [...await stemmer(object[fieldName])]
+            object[fullTextField] = [...stemmer(object[fieldName])]
             break
         default:
     }
@@ -284,7 +284,7 @@ export async function _processFieldsForWrites(def: CollectionDefinition, object,
         }
 
         if (fieldDef._index != null) {
-            await _processIndexedField(
+            _processIndexedField(
                 fieldName,
                 def.indices[fieldDef._index],
                 fieldDef,

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -6,7 +6,7 @@ import { StorageRegistry } from 'storex'
 import * as backend from 'storex/lib/types/backend'
 import { augmentCreateObject } from 'storex/lib/backend/utils'
 import { getDexieHistory, getTermsIndex } from './schema'
-import { DexieMongoify, DexieSchema } from './types'
+import { DexieMongoify, DexieSchema, UpdateOps } from './types'
 import { IndexDefinition, CollectionField, CollectionDefinition } from 'storex/lib/types';
 import { StorageBackendFeatureSupport } from 'storex/lib/types/backend-features';
 import { UnimplementedError, InvalidOptionsError } from 'storex/lib/types/errors';
@@ -188,11 +188,15 @@ export class DexieStorageBackend extends backend.StorageBackend {
     }
 
     async updateObjects(collection : string, query, updates, options : backend.UpdateManyOptions & {_transaction?} = {}) : Promise<backend.UpdateManyResult> {
-        const { modifiedCount } = await this.dexie
-            .collection(collection)
-            .update(query, updates)
+        const collectionDefinition = this.registry.collections[collection]
 
-        // return modifiedCount
+        const objects = await this.findObjects(collection, query, options)
+
+        for (const object of objects) {
+            _processFieldUpdates(updates, object)
+            await _processFieldsForWrites(collectionDefinition, object, this.stemmer)
+            await this.dexie.table(collection).put(object)
+        }
     }
 
     async deleteObjects(collection : string, query, options : backend.DeleteManyOptions = {}) : Promise<backend.DeleteManyResult> {
@@ -205,6 +209,43 @@ export class DexieStorageBackend extends backend.StorageBackend {
 
     async countObjects(collection : string, query) {
         return this.dexie.collection(collection).count(query)
+    }
+}
+
+
+/**
+ * Handles mutation of a document, updating each field in the way specified
+ * in the `updates` object.
+ * See for more info: https://github.com/YurySolovyov/dexie-mongoify/blob/master/docs/update-api.md
+ *
+ * TODO: Proper runtime error handling for badly formed update objs.
+ */
+export function _processFieldUpdates(updates, object) {
+    // TODO: Find a home for this
+    // TODO: Support all update ops
+    const updateOpAppliers: UpdateOps = {
+        $inc: (obj, key, value) => (obj[key] += value),
+        $set: (obj, key, value) => (obj[key] = value),
+        $mul: (obj, key, value) => (obj[key] *= value),
+        $unset: (obj, key) => (obj[key] = undefined),
+        $rename: () => undefined,
+        $min: () => undefined,
+        $max: () => undefined,
+        $addToSet: () => undefined,
+        $pop: () => undefined,
+        $push: () => undefined,
+        $pull: () => undefined,
+        $pullAll: () => undefined,
+        $slice: () => undefined,
+        $sort: () => undefined,
+    }
+
+    for (const [updateKey, updateVal] of Object.entries(updates)) {
+        // If supported update op, run assoc. update op applier
+        if (updateOpAppliers[updateKey] != null) {
+            Object.entries(updateVal).forEach(([key, val]) =>
+                updateOpAppliers[updateKey](object, key, val))
+        }
     }
 }
 

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -22,3 +22,22 @@ export interface DexieSchema {
         [collName: string]: string
     }
 }
+
+export type UpdateOpApplier<V=any> = (object, key: string, value: V) => void
+
+export interface UpdateOps { 
+    $inc: UpdateOpApplier<number>
+    $mul: UpdateOpApplier<number>
+    $rename: UpdateOpApplier
+    $set: UpdateOpApplier
+    $unset: UpdateOpApplier
+    $min: UpdateOpApplier
+    $max: UpdateOpApplier
+    $addToSet: UpdateOpApplier
+    $pop: UpdateOpApplier
+    $push: UpdateOpApplier
+    $pull: UpdateOpApplier
+    $pullAll: UpdateOpApplier
+    $slice: UpdateOpApplier
+    $sort: UpdateOpApplier
+}


### PR DESCRIPTION
- fixes #2 
- seems to fix the issue in Memex
- doesn't support all update ops yet, just picked out some common ones like `$set`, `$inc`, etc
- see f0d0557 for more info