### PR TITLE
Update for storex test changes

### DIFF
--- a/ts/index.test.ts
+++ b/ts/index.test.ts
@@ -26,7 +26,7 @@ describe('Dexie StorageBackend full-text search with Memex stemmer tests', () =>
     })
 })
 
-describe('Dexie StorageBackend batch operations', () => {
+describe('Dexie StorageBackend specific operations', () => {
     async function setupTest({userFields = null} = {}) {
         const backend = new DexieStorageBackend({dbName: 'unittest', idbImplementation: inMemory()})
         const storageManager = new StorageManager({backend})
@@ -50,40 +50,6 @@ describe('Dexie StorageBackend batch operations', () => {
         await storageManager.finishInitialization()
         return { storageManager }
     }
-
-    it('should support batches with updateObjects operations', async () => {
-        const { storageManager } = await setupTest()
-        const { object: object1 } = await storageManager.collection('user').createObject({displayName: 'Jack'})
-        const { object: object2 } = await storageManager.collection('user').createObject({displayName: 'Jane'})
-        await storageManager.operation('executeBatch', [
-            { operation: 'updateObjects', collection: 'user', where: {id: object1.id}, updates: {displayName: 'Jack 2'} },
-            { operation: 'updateObjects', collection: 'user', where: {id: object2.id}, updates: {displayName: 'Jane 2'} },
-        ])
-        expect([
-            await storageManager.collection('user').findOneObject({id: object1.id}),
-            await storageManager.collection('user').findOneObject({id: object2.id}),
-        ]).toEqual([
-            {id: object1.id, displayName: 'Jack 2'},
-            {id: object2.id, displayName: 'Jane 2'},
-        ])
-    })
-
-    it('should support batches with deleteObjects operations', async () => {
-        const { storageManager } = await setupTest()
-        const { object: object1 } = await storageManager.collection('user').createObject({displayName: 'Jack'})
-        const { object: object2 } = await storageManager.collection('user').createObject({displayName: 'Jane'})
-        await storageManager.operation('executeBatch', [
-            { operation: 'deleteObjects', collection: 'user', where: {id: object1.id} },
-            { operation: 'deleteObjects', collection: 'user', where: {id: object2.id} },
-        ])
-        expect([
-            await storageManager.collection('user').findOneObject({id: object1.id}),
-            await storageManager.collection('user').findOneObject({id: object2.id}),
-        ]).toEqual([
-            null,
-            null,
-        ])
-    })
 
     describe('flattenBatch()', () => {
         it('should flatten batches with complex creates', async () => {
@@ -141,5 +107,5 @@ describe('Dexie StorageBackend batch operations', () => {
                 },
             ])
         })
-    })    
+    })
 })


### PR DESCRIPTION
This corresponds to the test updates done in the storex repo in
https://github.com/WorldBrain/storex/pull/15

I also tried to unify those `testStorageBackend` and `testStorageBackendFullTextSearch` test suite calls in 270f5b2 by instead just setting the `fullTextSearch` flag in the second args to `testStorageBackend`. 
That works fine, but the issue is the previously separate backend instances were being tested with varying `stemmer` and `stemmerSelector` args are now not being tested anymore. I could call `testStorageBackend` twice with separate backend instances, although then all the tests are going to be run twice regardless if they're related to those stemmer args. Not sure if that's undesirable or it doesn't really matter?

Any ideas what you want to do here @ShishKabab ?